### PR TITLE
Changed color of Expand, Edit and Preview buttons to match.

### DIFF
--- a/components/Repo.js
+++ b/components/Repo.js
@@ -199,14 +199,12 @@ const Title = pure(function Title () {
 
   if (state.current.editable.get()) {
     buttons.push(
-      h('p.control', {key: 'fullscreen'}, [
-        h('button.button.is-primary.is-small.is-inverted', {
+      h('p.control', {key: 'fullscreen', onClick: () => state.fullscreen.set(!state.fullscreen.get())}, [
+        h('button.button.is-primary.is-small.is-inverted.button-list', {
           className: state.fullscreen.get() ? '' : 'is-outlined'
         }, [
-          h('span.icon.is-small', [ h('i.fa.fa-expand') ]),
-          h('span', {
-            onClick: () => state.fullscreen.set(!state.fullscreen.get())
-          }, state.fullscreen.get() ? 'Expanded' : 'Expand')
+          h('span.icon.is-small',  [ h('i.fa.fa-expand') ]),
+          h('span', state.fullscreen.get() ? 'Collapse' : 'Expand')
         ])
       ])
     )
@@ -222,26 +220,22 @@ const Title = pure(function Title () {
     )
   ) {
     buttons.push(
-      h('p.control', {key: 'edit'}, [
-        h('button.button.is-info.is-small.is-inverted', {
+      h('p.control', {key: 'edit', onClick: () => state.current.previewing.set(false)}, [
+        h('button.button.is-info.is-small.is-inverted.button-list', {
           className: state.current.previewing.get() ? 'is-outlined' : ''
         }, [
           h('span.icon.is-small', [ h('i.fa.fa-pencil-square') ]),
-          h('span', {
-            onClick: () => state.current.previewing.set(false)
-          }, 'Edit')
+          h('span', 'Edit')
         ])
       ])
     )
     buttons.push(
-      h('p.control', {key: 'preview'}, [
-        h('button.button.is-warning.is-small.is-inverted', {
+      h('p.control', {key: 'preview', onClick: () => state.current.previewing.set(true)}, [
+        h('button.button.is-warning.is-small.is-inverted.button-list', {
           className: state.current.previewing.get() ? '' : 'is-outlined'
         }, [
           h('span.icon.is-small', [ h('i.fa.fa-eye') ]),
-          h('span', {
-            onClick: () => state.current.previewing.set(true)
-          }, 'Preview')
+          h('span', 'Preview')
         ])
       ])
     )

--- a/main.scss
+++ b/main.scss
@@ -238,3 +238,13 @@ button.button {
 }
 
 .menu-list a { padding: 0 .75em; }
+
+.button-list {
+  color: #646363 !important;
+  border-color: #565656 !important;
+  background-color: transparent !important;
+  &:hover {
+    color: #bcf7d3 !important;
+    background-color: #646363 !important; 
+  }
+}


### PR DESCRIPTION
These buttons exist on the Repo page when you open a file. The current version looks like this: http://puu.sh/xxiyb/5d8a21c5ac.png  
This pull request version looks like this: http://puu.sh/xxiCE/f1f68200b7.png  
Also currently, the buttons only respond and trigger the onClick event if you click the text of the button. I changed this so that if you click anywhere on the button, it will trigger the onClick event.  